### PR TITLE
Canadian addresses & unit

### DIFF
--- a/lib/normalic/address.rb
+++ b/lib/normalic/address.rb
@@ -1,11 +1,12 @@
 require File.expand_path('../constants', File.dirname(__FILE__))
+require 'pry'
 
 module Normalic
   # only handles U.S. addresses
   class Address
     UNIT_TYPE_REGEX = /ap(artmen)?t|box|building|bldg|dep(artmen)?t|fl(oor)?|po( box)?|r(oo)?m|s(ui)?te|un(i)?t/
-    REGEXES = {:country => /usa/,
-               :zipcode => /\d{5}(-\d{4})?/,
+    REGEXES = {:country => /usa|ca/,
+               :zipcode => /((\d{5}(-\d{4})?)|([abceghjklmnrstvxy]{1}\d{1}[a-z]{1} ?\d{1}[a-z]{1}\d{1}))/,
                :state => Regexp.new(STATE_CODES.values * '|' + '|' +
                                     STATE_CODES.keys * '|'),
                :city => /\w+(\s\w+)*/,
@@ -205,7 +206,12 @@ module Normalic
     end
 
     def self.normalize_zipcode(zipcode)
-      zipcode ? zipcode[0,5] : nil
+      return nil unless zipcode
+      if (6..7).include? zipcode.length
+        "#{zipcode[0..2]} #{zipcode[-3..-1]}".upcase
+      else
+        zipcode[0, 5]
+      end
     end
 
     def self.normalize_state(state, zipcode=nil)

--- a/lib/normalic/address.rb
+++ b/lib/normalic/address.rb
@@ -15,7 +15,7 @@ module Normalic
                :directional => Regexp.new(DIRECTIONAL.keys * '|' + '|' +
                                           DIRECTIONAL.values * '|'),
                :type => Regexp.new(STREET_TYPES_LIST * '|'),
-               :number => /\d+/,
+               :number => /[NWSE]?\d+/,
                :street => /\w+(\s\w+)*/,
                :intersection => /(.+)\W+(and|&)\W+(.+)/}
 

--- a/spec/normalic_spec.rb
+++ b/spec/normalic_spec.rb
@@ -253,6 +253,30 @@ describe "Normalic::Address" do
     addr[:intersection].should == false
   end
 
+  it "should normalize a canadian address" do
+    addr = Normalic::Address.parse("800 Reynolds Dr, Kincardine, ON N2Z 3A5")
+    addr[:number].should == "800"
+    addr[:direction].should == nil
+    addr[:street].should == "Reynolds"
+    addr[:type].should == "Dr."
+    addr[:city].should == "Kincardine"
+    addr[:state].should == "ON"
+    addr[:zipcode].should == "N2Z 3A5"
+    addr[:intersection].should == false
+  end
+
+  it "should normalize a canadian address with unspaced postal code" do
+    addr = Normalic::Address.parse("800 Reynolds Dr, Kincardine, ON N2Z3A5")
+    addr[:number].should == "800"
+    addr[:direction].should == nil
+    addr[:street].should == "Reynolds"
+    addr[:type].should == "Dr."
+    addr[:city].should == "Kincardine"
+    addr[:state].should == "ON"
+    addr[:zipcode].should == "N2Z 3A5"
+    addr[:intersection].should == false
+  end
+
   it "should parse an address with no city info" do
     addr = Normalic::Address.parse("871 Washington Street")
     addr[:number].should == "871"

--- a/spec/normalic_spec.rb
+++ b/spec/normalic_spec.rb
@@ -217,6 +217,19 @@ describe "Normalic::Address" do
     addr[:intersection].should == false
   end
 
+  it "should parse a post office box" do
+    addr = Normalic::Address.parse("PO BOX 553, Asquith, SK S0K0J0")
+    addr[:unit].should == "Po Box 553"
+    addr[:number].should == nil
+    addr[:direction].should == nil
+    addr[:street].should == nil
+    addr[:type].should == nil
+    addr[:city].should == "Asquith"
+    addr[:state].should == "SK"
+    addr[:zipcode].should == "S0K 0J0"
+    addr[:intersection].should == false
+  end
+
   it "should parse an address with no state info" do
     addr = Normalic::Address.parse("416 W 13th Street, New York, 10014")
     addr[:number].should == "416"
@@ -357,6 +370,22 @@ describe "Normalic::Address" do
     addr[:city].should == "New York"
     addr[:state].should == "NY"
     addr[:zipcode].should == "10014"
+    addr[:intersection].should == false
+  end
+
+  it "should parse a post office box from a hash of fields" do
+    addr = Normalic::Address.normalize_fields(:address => "PO BOX 553",
+                                              :city => "Asquith",
+                                              :state => "SK",
+                                              :zipcode => "S0K0J0")
+    addr[:number].should == nil
+    addr[:direction].should == nil
+    addr[:street].should == nil
+    addr[:type].should == nil
+    addr[:unit].should == "Po Box 553"
+    addr[:city].should == "Asquith"
+    addr[:state].should == "SK"
+    addr[:zipcode].should == "S0K 0J0"
     addr[:intersection].should == false
   end
 


### PR DESCRIPTION
Two adds:
Canadian states/provinces and codes were already in the list, so I've added Canadian postal code handling. I can't easily find a list of Canadian postal codes => cities so I haven't updated the city map hash.

I moved the existing unit/po box parsing and added unit as an attribute. This stops po boxes from coming back as odd looking street names, and keeps the apartment number so mail can be delivered.

I've added some specs, let me know if there is anything I should tidy up!
